### PR TITLE
Fix Vercel server path issue

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  serverRuntimeConfig: {
+    PROJECT_ROOT: __dirname,
+  },
+};


### PR DESCRIPTION
For some reason, an error is caused when you try to read a file from an API route in NextJS when you've deployed your app to Vercel.

More info here:
https://github.com/vercel/next.js/issues/8251