### PR TITLE
Avoid redeclaring functions on each re-render

### DIFF
--- a/components/Chart/Chart.tsx
+++ b/components/Chart/Chart.tsx
@@ -1,6 +1,5 @@
-import { useRef, useEffect, useState } from "react";
-import { scaleLinear } from "d3";
-
+import { useRef, useEffect, useState, useCallback } from "react";
+import { createXScale, createYScale } from "./utils";
 import { ChartContainer, SignalWrapper } from "./Chart.styles";
 import { Point, YAxis } from "./components";
 
@@ -31,15 +30,7 @@ const Chart = ({
 
   if (!signalsExist(signals)) return <div></div>;
 
-  const createXScale = signals =>
-    scaleLinear()
-      .domain([0, signals.length - 1])
-      .range([10, chartWidth - 30]);
-
-  const createYScale = val =>
-    scaleLinear().domain([val.min, val.max]).range([0, 370]);
-
-  const scaleX = createXScale(signals);
+  const scaleX = createXScale(signals, chartWidth);
 
   const scaleVal1 = createYScale(signalMinMaxes.signal1);
   const scaleVal2 = createYScale(signalMinMaxes.signal2);

--- a/components/Chart/utils.js
+++ b/components/Chart/utils.js
@@ -1,0 +1,9 @@
+import { scaleLinear } from "d3";
+
+export const createXScale = (signals, chartWidth) =>
+  scaleLinear()
+    .domain([0, signals.length - 1])
+    .range([10, chartWidth - 30]);
+
+export const createYScale = val =>
+  scaleLinear().domain([val.min, val.max]).range([0, 370]);


### PR DESCRIPTION
Place D3 `createScale` functions in a utils file to avoid re-declaring them on each render.